### PR TITLE
Add PracticeLoop to guitar practice tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You might also like [awesome-sheet-music](https://github.com/adius/awesome-sheet
 - [GuitarStack](https://github.com/lucaong/guitarstack) - Browser-based effect stack for electric guitars.
 - [Pedalboard](https://github.com/DeerMichel/pedalboard) - Online pedalboard for audio manipulation.
 - [Fretboard for Guitar and Ukulele](https://guitarstreams.com/tool/fretboard/) - Interactive fretboard for guitar and ukulele.
+- [PracticeLoop](https://teal-semifreddo-cad4ad.netlify.app/) - Slow down & loop YouTube videos for guitar practice with progressive speed training.
 
 ## Building
 


### PR DESCRIPTION
## What is PracticeLoop?

PracticeLoop is a free web-based practice tool designed specifically for guitarists (and all musicians) to practice difficult passages from YouTube videos.

**Features:**
- **Slow down YouTube videos** from 0.25x to 2x speed without pitch change
- **A-B loop** any section to practice it repeatedly
- **Progressive speed training** - automatically increases playback speed after N loop reps (unique feature, no competitor offers this)
- **Built-in metronome** with tap tempo and multiple time signatures
- **Practice timer** with session tracking and streak system
- **Shareable URLs** - share specific practice sections with pre-configured speed/loop settings

**Why add it here?**
- Perfect fit for the "Tools > Websites" section
- Specifically designed for guitar practice (though works for bass, piano, drums, violin too)
- Free to use with no signup required
- Actively maintained and updated
- Fills a gap in the current list (no YouTube-based practice tools)

**Live demo:**
- Main app: https://teal-semifreddo-cad4ad.netlify.app/
- Guitar landing page: https://teal-semifreddo-cad4ad.netlify.app/guitar
- Try a pre-configured example: [Stairway to Heaven Solo at 0.5x](https://teal-semifreddo-cad4ad.netlify.app/?v=BcL---4xQYA&start=336&end=358&speed=0.5)

Happy to make any adjustments if needed!