### PR TITLE
Add GuitarToneAdapt to Tools > Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You might also like [awesome-sheet-music](https://github.com/adius/awesome-sheet
 - [GuitarStack](https://github.com/lucaong/guitarstack) - Browser-based effect stack for electric guitars.
 - [Pedalboard](https://github.com/DeerMichel/pedalboard) - Online pedalboard for audio manipulation.
 - [Fretboard for Guitar and Ukulele](https://guitarstreams.com/tool/fretboard/) - Interactive fretboard for guitar and ukulele.
+- [GuitarToneAdapt](https://guitartoneadapt.com/) - Researched amp & guitar settings behind famous song tones, adapted to your own rig.
 
 ## Building
 


### PR DESCRIPTION
Adds **GuitarToneAdapt** under Tools > Websites — a free, no-signup web tool that takes the original amp/EQ/gain settings of famous guitar tones and re-dials them for the exact guitar, amp and pickups you actually own (compensating for pickup output, brightness and amp voicing).

- Free, runs in the browser, no account.
- Format follows the contributing guidelines: `[name](link) - Description.`
- Fits the existing Websites list (interactive guitar tools).